### PR TITLE
Allow guiders to 'process' booking requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: ruby
+addons:
+  chrome: stable
 cache:
   bundler: true
   yarn: true

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,10 @@ group :development do
 end
 
 group :test do
+  gem 'chromedriver-helper'
   gem 'database_rewinder'
+  gem 'launchy'
+  gem 'selenium-webdriver'
   gem 'site_prism'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    archive-zip (0.11.0)
+      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     autoprefixer-rails (9.0.0)
@@ -74,6 +76,11 @@ GEM
       xpath (~> 3.1)
     case_transform (0.2)
       activesupport
+    childprocess (0.9.0)
+      ffi (~> 1.0, >= 1.0.11)
+    chromedriver-helper (1.2.0)
+      archive-zip (~> 0.10)
+      nokogiri (~> 1.8)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
     connection_pool (2.2.2)
@@ -114,6 +121,7 @@ GEM
     hashie (3.5.7)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jquery-rails (4.3.3)
       rails-dom-testing (>= 1, < 3)
@@ -133,6 +141,8 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -225,23 +235,23 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     redis (4.0.1)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-rails (3.7.2)
+      rspec-support (~> 3.8.0)
+    rspec-rails (3.8.0)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       railties (>= 3.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     rubocop (0.58.2)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
@@ -252,6 +262,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     ruby_dep (1.5.0)
+    rubyzip (1.2.1)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -267,6 +278,9 @@ GEM
       sprockets (> 2.11)
       sprockets-rails
       tilt
+    selenium-webdriver (3.14.0)
+      childprocess (~> 0.5)
+      rubyzip (~> 1.2)
     sidekiq (5.1.3)
       concurrent-ruby (~> 1.0)
       connection_pool (~> 2.2, >= 2.2.0)
@@ -309,6 +323,7 @@ DEPENDENCIES
   bootstrap-kaminari-views
   bugsnag
   capybara (~> 3.2.0)
+  chromedriver-helper
   database_rewinder
   email_validator
   factory_bot_rails
@@ -316,6 +331,7 @@ DEPENDENCIES
   gds-sso
   govuk_admin_template
   kaminari
+  launchy
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   plek
@@ -326,6 +342,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   sassc-rails
+  selenium-webdriver
   sidekiq
   site_prism
   uglifier (>= 1.3.0)

--- a/app/assets/stylesheets/components/_action-buttons.scss
+++ b/app/assets/stylesheets/components/_action-buttons.scss
@@ -1,0 +1,5 @@
+.action-buttons {
+  margin-top: 1.4em;
+  text-align: right;
+  white-space: nowrap;
+}

--- a/app/controllers/processes_controller.rb
+++ b/app/controllers/processes_controller.rb
@@ -1,0 +1,8 @@
+class ProcessesController < ApplicationController
+  def create
+    @booking_request = BookingRequest.find(params[:booking_request_id])
+    @booking_request.process!
+
+    redirect_back success: 'The booking request was marked as processed.', fallback_location: root_path
+  end
+end

--- a/app/models/booking_request.rb
+++ b/app/models/booking_request.rb
@@ -15,4 +15,8 @@ class BookingRequest < ApplicationRecord
   def face_to_face?
     location_id.present?
   end
+
+  def process!
+    touch(:processed_at) unless processed_at? # rubocop:disable SkipsModelValidations
+  end
 end

--- a/app/views/booking_requests/show.html.erb
+++ b/app/views/booking_requests/show.html.erb
@@ -7,7 +7,20 @@
     <li class="active">Booking request for <%= @booking_request.full_name %></li>
   </ol>
 
-  <h1>Booking request for <%= @booking_request.full_name %></h1>
+  <div class="row">
+    <div class="col-md-7">
+      <h1>Booking request for <%= @booking_request.full_name %></h1>
+    </div>
+
+    <div class="col-md-5 action-buttons">
+      <% unless @booking_request.processed_at? %>
+        <%= link_to booking_request_process_path(@booking_request), method: :post, title: 'Mark as processed', class: 'btn btn-info t-process' do %>
+          <span class="glyphicon glyphicon-flag" aria-hidden="true"></span>
+          <span>Mark as processed</span>
+        <% end %>
+      <% end %>
+    </div>
+  </div>
 </div>
 
 <div class="row">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,9 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :booking_requests, only: %i[index show]
+  resources :booking_requests, only: %i[index show] do
+    resource :process, only: :create
+  end
 
   root 'booking_requests#index'
 end

--- a/spec/features/guider_processes_a_booking_request_spec.rb
+++ b/spec/features/guider_processes_a_booking_request_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.feature 'Guider processes a booking request' do
+  scenario 'Successfully processing a booking request', js: true do
+    given_the_user_identifies_as(:guider) do
+      and_an_unprocessed_booking_request_exists
+      when_the_guider_views_the_booking
+      and_processes_the_booking
+      then_the_booking_is_processed
+      and_the_guider_is_informed
+    end
+  end
+
+  def and_an_unprocessed_booking_request_exists
+    @booking = create(:booking_request)
+  end
+
+  def when_the_guider_views_the_booking
+    @page = Pages::BookingRequest.new
+    @page.load(id: @booking.id)
+
+    expect(@page).to be_displayed
+  end
+
+  def and_processes_the_booking
+    @page.process.click
+  end
+
+  def then_the_booking_is_processed
+    expect(@page.processed).to have_text('Yes')
+  end
+
+  def and_the_guider_is_informed
+    expect(@page).to have_text('was marked as processed')
+  end
+end

--- a/spec/support/chrome.rb
+++ b/spec/support/chrome.rb
@@ -1,0 +1,13 @@
+require 'chromedriver/helper'
+require 'selenium/webdriver'
+
+Chromedriver.set_version('2.38')
+
+Capybara.register_driver :chrome do |app|
+  options = Selenium::WebDriver::Chrome::Options.new(args: %w[headless no-sandbox])
+
+  Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
+end
+
+Capybara.server = :puma, { Silent: true }
+Capybara.javascript_driver = :chrome

--- a/spec/support/pages/booking_request.rb
+++ b/spec/support/pages/booking_request.rb
@@ -16,5 +16,8 @@ module Pages
     element :defined_contribution_pot_confirmed_yes, '.t-defined-contribution-pot-confirmed-yes'
     element :defined_contribution_pot_confirmed_dont_know, '.t-defined-contribution-pot-confirmed-dont-know'
     element :gdpr_consent, '.t-gdpr-consent'
+    element :processed, '.t-processed'
+
+    element :process, '.t-process'
   end
 end


### PR DESCRIPTION
Lets the guider mark a booking request as 'processed'. This means they
have entered the booking request in their other systems.