### PR TITLE
Remove Rails 12 factor gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,3 @@ group :test do
   gem 'site_prism'
   gem 'webmock'
 end
-
-group :staging, :production do
-  gem 'rails_12factor'
-end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -238,11 +238,6 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    rails_12factor (0.0.3)
-      rails_serve_static_assets
-      rails_stdout_logging
-    rails_serve_static_assets (0.0.5)
-    rails_stdout_logging (0.0.5)
     railties (6.0.2.2)
       actionpack (= 6.0.2.2)
       activesupport (= 6.0.2.2)
@@ -363,7 +358,6 @@ DEPENDENCIES
   pry-byebug
   puma
   rails (~> 6.0)
-  rails_12factor
   rspec-rails
   rubocop (= 0.58.2)
   sassc-rails


### PR DESCRIPTION
This hasn't been needed since Rails 5.